### PR TITLE
Fix issue - Cannot convert System.Object to System.String

### DIFF
--- a/files/default/install.ps1
+++ b/files/default/install.ps1
@@ -65,7 +65,7 @@ function install-devtools($destination, $version)
 
     $winbox = install-gitrepo https://github.com/adamedx/winbox $destination $version
 
-    cd $winbox
+    iex "& cd $winbox"
     rm .\berksfile.lock -erroraction ignore
     berks vendor cookbooks
     & chef-client --color -z -o winbox


### PR DESCRIPTION
Fixes an issue where the script fails because the install-gitrepo function returns a Powershell block which cannot be passed directly to the cd command.
