### PR TITLE
Warning message if not running as administrator

### DIFF
--- a/files/default/winbox-ps-profile.ps1
+++ b/files/default/winbox-ps-profile.ps1
@@ -25,9 +25,23 @@ Set-PSReadlineOption -EditMode Emacs
 $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
 $principal = [Security.Principal.WindowsPrincipal] $identity
 $titleprefix = ""
-if (test-path variable:/PSDebugContext) { $titleprefix = 'Debug: ' }
-elseif($principal.IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
-{ $titleprefix = "Administrator: " }
+if (test-path variable:/PSDebugContext) {
+  $titleprefix = 'Debug: '
+}
+else
+{
+  if ($principal.IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
+  {
+    $titleprefix = "Administrator: "
+    Write-Host -foregroundcolor green "Running as Administrator`n "
+  }
+  else
+  {
+    Write-Warning "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    Write-Warning "!You are NOT running as Administrator!"
+    Write-Warning "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`n "
+  }
+}
 
 #
 # The title will look like one of the following:


### PR DESCRIPTION
@adamedx Added a warning if not running as administrator (and confirmation output if running as admin).   Lost a bunch of time trying to figure out why a test was failing, and it was due to not running as admin, so this more explicit warning will hopefully save someone else time.
