### PR TITLE
Pass -UseBasicParsing to iwr

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The *Winbox* cookbook configures Windows workstations for developers. It configu
 
 Copy the following command and paste it into a PowerShell session and run it to install *Winbox* and all its prerequisites:
 ```powershell
-. { iwr https://raw.githubusercontent.com/adamedx/winbox/0.1.79/files/default/install.ps1 } |
+. { iwr -UseBasicParsing https://raw.githubusercontent.com/adamedx/winbox/0.1.79/files/default/install.ps1 } |
 iex;install-workstation
 ```
 See additonal instructions for customization and advanced usage and non-default features.


### PR DESCRIPTION
Without a fresh windows 10 box errors with

```
iex : File C:\Users\jdmun\Documents\pantry-chef-repo\bin\pantry.ps1 cannot be loaded because running scripts is
disabled on this system. For more information, see about_Execution_Policies at
http://go.microsoft.com/fwlink/?LinkID=135170.
At line:59 char:5
+     iex "& '$dest\bin\pantry.ps1' -runchef"
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : SecurityError: (:) [Invoke-Expression], PSSecurityException
    + FullyQualifiedErrorId : UnauthorizedAccess,Microsoft.PowerShell.Commands.InvokeExpressionCommand
```

Seems like it wants me to run Internet Explorer. That's annoying, but
passing -UseBasicParsing fixes this.

Fixes #5
