### PR TITLE
download newest stable version of vs code

### DIFF
--- a/recipes/editor.rb
+++ b/recipes/editor.rb
@@ -32,7 +32,7 @@ if node['platform'] == "windows"
     end
 
     remote_file download_path do
-      source 'https://az764295.vo.msecnd.net/public/0.8.0/VSCodeSetup.exe'
+      source 'https://vscode-update.azurewebsites.net/latest/win32-x64/stable'
     end
 
     powershell_script 'install vscode' do


### PR DESCRIPTION
when running master of winbox on a new windows instance, it appears
that we're downloading and installing version 0.8.0 of vs code, and
as soon as it tries to start up the user is instructed to install
a non pre-release version. this link *should* continue to be the
stable link.

I yanked it from the vs code downloads page and it redirects to the
current stable artifact.

Signed-off-by: Stephen Delano <stephen@chef.io>